### PR TITLE
Added support for ignore option for glob.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ var concatenated = concat(sourceTree, {
   inputFiles: [
     'app/**/*.css'
   ],
+  ignore: [
+    'app/lib/**'
+  ],
   outputFile: '/assets/app.css',
   separator: '\n', // (optional, defaults to \n)
   wrapInEval: true, // (optional, defaults to false)
@@ -25,6 +28,7 @@ var concatenated = concat(sourceTree, {
 ## Options
 
 * inputFiles - the order of files may be important to solve dependencies, [globbing](https://www.npmjs.org/package/glob) is also supported
+* ignore - a pattern or array of patterns to exclude files from the concat operation, [globbing](https://www.npmjs.org/package/glob) is also supported
 * separator - what to separate the files with, defaults to '\n'
 * wrapInEval - whether to wrap in eval for sourceURL, defaults to false as causes problems with global variables
 * wrapInFunction - whether to wrap output in self-invoking function when wrapping output in eval, defaults to true

--- a/index.js
+++ b/index.js
@@ -68,7 +68,11 @@ Concat.prototype.write = function (readTree, destDir) {
     var newCache = {}
 
     try {
-      var inputFiles = helpers.multiGlob(filterInputFiles(self, srcDir), {cwd: srcDir})
+      var globOptions = {cwd: srcDir};
+      if (self.ignore) {
+        globOptions.ignore = self.ignore;
+      }
+      var inputFiles = helpers.multiGlob(filterInputFiles(self, srcDir), globOptions);
       for (i = 0; i < inputFiles.length; i++) {
         var stat = getStat(srcDir + '/' + inputFiles[i]);
         if (stat && stat.isFile()) {


### PR DESCRIPTION
We need to exclude some files in our concat operation to build two different versions of our project.

This change is needed to pass along the `ignore` option to `glob`.