### PR TITLE
Make inputFiles parameter default to all files

### DIFF
--- a/concat.js
+++ b/concat.js
@@ -19,11 +19,8 @@ function ConcatWithMaps(inputNode, options, Strategy) {
     throw new Error('the outputFile option is required');
   }
 
-  var defaultInputFiles = ['**/*'];
-  var inputFiles = options.inputFiles || defaultInputFiles;
-
   CachingWriter.call(this, [inputNode], {
-    inputFiles: inputFiles,
+    inputFiles: options.inputFiles,
     annotation: options.annotation,
     name: (Strategy.name || 'Unknown') + 'Concat'
   });
@@ -34,7 +31,7 @@ function ConcatWithMaps(inputNode, options, Strategy) {
 
   this.Strategy = Strategy;
   this.sourceMapConfig = omit(options.sourceMapConfig || {}, 'enabled');
-  this.inputFiles = inputFiles;
+  this.inputFiles = options.inputFiles;
   this.outputFile = options.outputFile;
   this.allowNone = options.allowNone;
   this.header = options.header;

--- a/concat.js
+++ b/concat.js
@@ -15,12 +15,15 @@ function ConcatWithMaps(inputNode, options, Strategy) {
     return new ConcatWithMaps(inputNode, options, Strategy);
   }
 
-  if (!options || !options.outputFile || !options.inputFiles) {
-    throw new Error('inputFiles and outputFile options are required');
+  if (!options || !options.outputFile) {
+    throw new Error('the outputFile option is required');
   }
 
+  var defaultInputFiles = ['**/*'];
+  var inputFiles = options.inputFiles || defaultInputFiles;
+
   CachingWriter.call(this, [inputNode], {
-    inputFiles: options.inputFiles,
+    inputFiles: inputFiles,
     annotation: options.annotation,
     name: (Strategy.name || 'Unknown') + 'Concat'
   });
@@ -31,7 +34,7 @@ function ConcatWithMaps(inputNode, options, Strategy) {
 
   this.Strategy = Strategy;
   this.sourceMapConfig = omit(options.sourceMapConfig || {}, 'enabled');
-  this.inputFiles = options.inputFiles;
+  this.inputFiles = inputFiles;
   this.outputFile = options.outputFile;
   this.allowNone = options.allowNone;
   this.header = options.header;

--- a/test/test.js
+++ b/test/test.js
@@ -43,6 +43,17 @@ describe('sourcemap-concat', function() {
     });
   });
 
+  it('concatenates all files across dirs when inputFiles is not specified', function() {
+    var node = concat(firstFixture, {
+      outputFile: '/all.js'
+    });
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function(result) {
+      expectFile('all.js').in(result);
+      expectFile('all.map').in(result);
+    });
+  });
+
   it('inserts header', function() {
     var node = concat(firstFixture, {
       outputFile: '/all-with-header.js',


### PR DESCRIPTION
With this change, this is the new simplest possible `concat` call:

```js
var appJs = concat('js', {
    outputFile: '/all-js.js',
});
```

This makes the plugin easier to get started with.

Closes https://github.com/ember-cli/broccoli-concat/issues/36.