### PR TITLE
Assert that sourcemaps are actually valid + empty map issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "chai-as-promised": "^5.3.0",
     "chai-files": "^1.2.0",
     "mocha": "^2.0.1",
-    "quick-temp": "^0.1.3"
+    "quick-temp": "^0.1.3",
+    "sourcemap-validator": "^1.0.4"
   },
   "dependencies": {
     "broccoli-caching-writer": "^2.0.0",


### PR DESCRIPTION
One of the tests (below) is failing as it is not valid to have an empty sourcemap:

``` js
  it('can ignore empty content', function() {
    var node = concat(firstFixture, {
      outputFile: '/nothing.js',
      inputFiles: ['nothing/*.js'],
      allowNone: true
    });
    builder = new broccoli.Builder(node);
    return builder.build().then(function(result) {
      expectValidSourcemap('nothing.js').in(result);
    });
  });
```

``` json
{"version":3,"sources":[],"sourcesContent":[],"names":[],"mappings":"","file":"nothing.js"}
```

```
  1) sourcemap-concat can ignore empty content:
     AssertionError: There were no sources in the file
```
