### PR TITLE
Update to latest minimatch to avoid deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lodash.merge": "^4.3.0",
     "lodash.omit": "^4.1.0",
     "lodash.uniq": "^4.2.0",
-    "minimatch": "^3.0.0",
+    "minimatch": "^3.0.2",
     "mkdirp": "^0.5.1"
   }
 }


### PR DESCRIPTION
Avoids `npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue`