### PR TITLE
[Bugfix release] ensure headerFiles / inputFiles / footerFiles are in…

### DIFF
--- a/concat.js
+++ b/concat.js
@@ -19,8 +19,10 @@ function ConcatWithMaps(inputNode, options, Strategy) {
     throw new Error('the outputFile option is required');
   }
 
+  var allInputFiles = uniq([].concat(options.headerFiles || [], options.inputFiles || [], options.footerFiles || []));
+
   CachingWriter.call(this, [inputNode], {
-    inputFiles: options.inputFiles,
+    inputFiles: allInputFiles.length === 0 ? undefined : allInputFiles,
     annotation: options.annotation,
     name: (Strategy.name || 'Unknown') + 'Concat'
   });


### PR DESCRIPTION
…cluded as inputFiles to BCW

* empty inputFiles to BCW would result in the whole base-dir being walked (so only having headerFiles/footerFiles would cause an issue)
* headerFiles/footerFiles that that do not exist in inputFiles would previously be ignored from cache-key construction, resulting in possible stale reads.