### PR TITLE
process.env.CONCAT_STATS enables debug output

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,25 @@ The structure of `output.js` will be as follows:
 // - ordered content of the files in footerFiles
 // - footer
 ```
+
+#### Debug Usage
+
+Setting the environment variable `CONCAT_STATS=true` will result a summary of
+each concatention being output to `process.cwd() + 'concat-stats-for/*.json'`
+
+Each file within that directory represents a different contenation, and will contain:
+
+* outputFile – the output file that was created
+* sizes – a summary of each input file, and the associated pre-minified pre-gziped byte size.
+
+##### Example:
+
+```json
+{
+  "outputFile": "path/to/output/File",
+  "sizes": {
+    "a.js": 5,
+    "b.js": 10,
+  }
+}
+```

--- a/concat-without-source-maps.js
+++ b/concat-without-source-maps.js
@@ -22,7 +22,7 @@ Simple.prototype.addSpace = function(space) {
 };
 
 Simple.prototype.writeConcatStatsSync = function(outputPath, content) {
-  fs.writeFileSync(outputPath, content);
+  fs.writeFileSync(outputPath, JSON.stringify(content, null, 2));
 };
 
 Simple.prototype.end = function(cb, thisArg) {
@@ -36,10 +36,10 @@ Simple.prototype.end = function(cb, thisArg) {
 
     this.writeConcatStatsSync(
       outputPath,
-      JSON.stringify({
+      {
         outputFile: this.outputFile,
         sizes: this._sizes
-      }, null, 2)
+      }
     )
   }
 

--- a/concat-without-source-maps.js
+++ b/concat-without-source-maps.js
@@ -7,14 +7,22 @@ function Simple(attrs) {
   this._internal = '';
   this.outputFile = attrs.outputFile;
   this.baseDir = attrs.baseDir;
+  this._sizes = {};
+  this.id = attrs.pluginId;
 }
 
 Simple.prototype.addFile = function(file) {
-  this._internal += fs.readFileSync(path.join(this.baseDir, file), 'UTF-8');
+  var content =  fs.readFileSync(path.join(this.baseDir, file), 'UTF-8');
+  this._internal += content;
+  this._sizes[file] = content.length;
 };
 
 Simple.prototype.addSpace = function(space) {
   this._internal += space;
+};
+
+Simple.prototype.writeConcatStatsSync = function(outputPath, content) {
+  fs.writeFileSync(outputPath, content);
 };
 
 Simple.prototype.end = function(cb, thisArg) {
@@ -22,6 +30,19 @@ Simple.prototype.end = function(cb, thisArg) {
   if (cb) {
     result = cb.call(thisArg, this);
   }
+
+  if (process.env.CONCAT_STATS) {
+    var outputPath = process.cwd() + '/concat-stats-for-' + this.id + '-' + path.basename(this.outputFile) + '.json';
+
+    this.writeConcatStatsSync(
+      outputPath,
+      JSON.stringify({
+        outputFile: this.outputFile,
+        sizes: this._sizes
+      }, null, 2)
+    )
+  }
+
   fs.writeFileSync(this.outputFile, this._internal);
   return result;
 };

--- a/concat-without-source-maps.js
+++ b/concat-without-source-maps.js
@@ -1,5 +1,5 @@
 'use strict';
-var fs = require('fs');
+var fs = require('fs-extra');
 var path = require('path');
 
 module.exports = Simple;
@@ -22,6 +22,7 @@ Simple.prototype.addSpace = function(space) {
 };
 
 Simple.prototype.writeConcatStatsSync = function(outputPath, content) {
+  fs.mkdirpSync(path.dirname(outputPath));
   fs.writeFileSync(outputPath, JSON.stringify(content, null, 2));
 };
 
@@ -32,7 +33,7 @@ Simple.prototype.end = function(cb, thisArg) {
   }
 
   if (process.env.CONCAT_STATS) {
-    var outputPath = process.cwd() + '/concat-stats-for-' + this.id + '-' + path.basename(this.outputFile) + '.json';
+    var outputPath = process.cwd() + '/concat-stats-for/' + this.id + '-' + path.basename(this.outputFile) + '.json';
 
     this.writeConcatStatsSync(
       outputPath,

--- a/concat.js
+++ b/concat.js
@@ -10,6 +10,7 @@ module.exports = ConcatWithMaps;
 ConcatWithMaps.prototype = Object.create(CachingWriter.prototype);
 ConcatWithMaps.prototype.constructor = ConcatWithMaps;
 
+var id = 0;
 function ConcatWithMaps(inputNode, options, Strategy) {
   if (!(this instanceof ConcatWithMaps)) {
     return new ConcatWithMaps(inputNode, options, Strategy);
@@ -26,6 +27,8 @@ function ConcatWithMaps(inputNode, options, Strategy) {
     annotation: options.annotation,
     name: (Strategy.name || 'Unknown') + 'Concat'
   });
+
+  this.id = (id++);
 
   if (Strategy === undefined) {
     throw new TypeError('ConcatWithMaps requires a concat Strategy');
@@ -79,7 +82,8 @@ ConcatWithMaps.prototype.build = function() {
   this.concat = new this.Strategy(merge(this.sourceMapConfig, {
     outputFile: outputFile,
     baseDir: this.inputPaths[0],
-    cache: this.encoderCache
+    cache: this.encoderCache,
+    pluginId: this.id
   }));
 
   return this.concat.end(function(concat) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
     "chai-files": "^1.2.0",
+    "fs-extra": "^0.30.0",
     "mocha": "^3.0.0",
     "quick-temp": "^0.1.3"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "test": "mocha",
-    "test:debug": "mocha debug"
+    "test:debug": "mocha --no-timeouts debug"
   },
   "repository": "https://github.com/ember-cli/broccoli-concat",
   "author": "Edward Faulkner <ef@alum.mit.edu>",

--- a/test/concat-without-maps-test.js
+++ b/test/concat-without-maps-test.js
@@ -85,7 +85,7 @@ describe('concat-without-maps', function() {
       concat.end();
       expect(outputs.length).to.eql(1);
 
-    var outputPath = process.cwd() + '/concat-stats-for-' + concat.id + '-' + path.basename(concat.outputFile) + '.json';
+    var outputPath = process.cwd() + '/concat-stats-for/' + concat.id + '-' + path.basename(concat.outputFile) + '.json';
       expect(outputs[0].outputPath).to.eql(outputPath);
       expect(outputs[0].content).to.eql({
         outputFile: concat.outputFile,

--- a/test/concat-without-maps-test.js
+++ b/test/concat-without-maps-test.js
@@ -1,0 +1,60 @@
+/* global describe, afterEach, beforeEach, it, expect */
+
+var concat = require('..');
+var fs = require('fs');
+var path = require('path');
+
+var chai = require('chai');
+var chaiFiles = require('chai-files');
+
+chai.use(chaiFiles);
+
+var expect = chai.expect;
+var file = chaiFiles.file;
+var firstFixture = path.join(__dirname, 'fixtures', 'first');
+
+describe('concat-without-maps', function() {
+  var Concat = require('../concat-without-source-maps');
+  var quickTemp = require('quick-temp');
+  var concat;
+  var outputFile;
+
+  beforeEach(function() {
+    outputFile = quickTemp.makeOrRemake(this, 'tmpDestDir') + '/' + 'foo.js';
+
+    concat = new Concat({
+      outputFile: outputFile,
+      baseDir: firstFixture
+    });
+  });
+
+  afterEach(function() {
+    quickTemp.remove(this, 'tmpDestDir');
+  });
+
+  it('addSpace', function() {
+    concat.addSpace('a');
+    concat.addSpace('b');
+    concat.addSpace('c');
+    concat.end();
+    expect(file(outputFile)).to.equal('abc');
+  });
+
+  it('addFile', function() {
+    concat.addFile('inner/first.js');
+    concat.addFile('inner/second.js');
+    concat.addFile('other/third.js');
+    concat.end();
+    expect(file(outputFile)).to.equal(file(__dirname + '/expected/concat-without-maps-1.js'));
+  });
+
+  it('addFile & addSpace', function() {
+    concat.addFile('inner/first.js');
+    concat.addSpace('"a";\n');
+    concat.addSpace('"b";\n');
+    concat.addSpace('"c";\n');
+    concat.addFile('inner/second.js');
+    concat.end();
+    expect(file(outputFile)).to.equal(file(__dirname + '/expected/concat-without-maps-2.js'));
+  });
+});

--- a/test/concat-without-maps-test.js
+++ b/test/concat-without-maps-test.js
@@ -57,4 +57,43 @@ describe('concat-without-maps', function() {
     concat.end();
     expect(file(outputFile)).to.equal(file(__dirname + '/expected/concat-without-maps-2.js'));
   });
+
+  describe('CONCAT_STATS', function() {
+    var outputs;
+
+    beforeEach(function() {
+      process.env.CONCAT_STATS = true;
+      outputs = [];
+
+      concat.writeConcatStatsSync = function(outputPath, content) {
+        outputs.push({
+          outputPath: outputPath,
+          content: content
+        });
+      };
+    });
+
+    afterEach(function() {
+      delete process.env.CONCAT_STATS;
+    });
+
+    it('correctly emits file for given concat', function() {
+      concat.addFile('inner/first.js');
+      concat.addFile('inner/second.js');
+
+      expect(outputs.length).to.eql(0);
+      concat.end();
+      expect(outputs.length).to.eql(1);
+
+    var outputPath = process.cwd() + '/concat-stats-for-' + concat.id + '-' + path.basename(concat.outputFile) + '.json';
+      expect(outputs[0].outputPath).to.eql(outputPath);
+      expect(outputs[0].content).to.eql({
+        outputFile: concat.outputFile,
+        sizes: {
+          'inner/first.js': 100,
+          'inner/second.js': 66
+        }
+      });
+    })
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -559,52 +559,6 @@ describe('sourcemap-concat', function() {
   });
 });
 
-describe('concat-without-maps', function() {
-  var Concat = require('../concat-without-source-maps');
-  var quickTemp = require('quick-temp');
-  var concat;
-  var outputFile;
-
-  beforeEach(function() {
-    outputFile = quickTemp.makeOrRemake(this, 'tmpDestDir') + '/' + 'foo.js';
-
-    concat = new Concat({
-      outputFile: outputFile,
-      baseDir: firstFixture
-    });
-  });
-
-  afterEach(function() {
-    quickTemp.remove(this, 'tmpDestDir');
-  });
-
-  it('addSpace', function() {
-    concat.addSpace('a');
-    concat.addSpace('b');
-    concat.addSpace('c');
-    concat.end();
-    expect(file(outputFile)).to.equal('abc');
-  });
-
-  it('addFile', function() {
-    concat.addFile('inner/first.js');
-    concat.addFile('inner/second.js');
-    concat.addFile('other/third.js');
-    concat.end();
-    expect(file(outputFile)).to.equal(file(__dirname + '/expected/concat-without-maps-1.js'));
-  });
-
-  it('addFile & addSpace', function() {
-    concat.addFile('inner/first.js');
-    concat.addSpace('"a";\n');
-    concat.addSpace('"b";\n');
-    concat.addSpace('"c";\n');
-    concat.addFile('inner/second.js');
-    concat.end();
-    expect(file(outputFile)).to.equal(file(__dirname + '/expected/concat-without-maps-2.js'));
-  });
-});
-
 function expectFile(filename) {
   var stripURL = false;
 


### PR DESCRIPTION
This output is written to disk at cwd +
concat-stats-for-<name-of-outputfile>.json and contains the sizes of the
various pieces the outputfile is made of.

This aims to enable improved debuggability / visibility of large output
assets.