### PR TITLE
Move fs-extra to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "chai-files": "^1.2.0",
-    "fs-extra": "^0.30.0",
     "mocha": "^3.0.0",
     "quick-temp": "^0.1.3",
     "walk-sync": "^0.3.1"
@@ -34,6 +33,7 @@
     "broccoli-kitchen-sink-helpers": "^0.3.1",
     "broccoli-stew": "^1.3.3",
     "fast-sourcemap-concat": "^1.0.1",
+    "fs-extra": "^0.30.0",
     "lodash.merge": "^4.3.0",
     "lodash.omit": "^4.1.0",
     "lodash.uniq": "^4.2.0",


### PR DESCRIPTION
Fresh install of [ember-engines](https://github.com/dgeb/ember-engines/blob/master/package.json#L57) was blowing up on me due to `fs-extra` not being installed.