### PR TITLE
`inputFiles` is ordered

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The structure of `output.js` will be as follows:
 ```
 // - header
 // - ordered content of the files in headerFiles
-// - un-ordered content of files matched by inputFiles, but not in headerFiles or footerFiles
+// - ordered content of files matched by inputFiles, but not in headerFiles or footerFiles
 // - ordered content of the files in footerFiles
 // - footer
 ```


### PR DESCRIPTION
What I can see `inputFiles` are ordered (https://github.com/ember-cli/broccoli-concat/blob/master/concat.js#L23).

Is it alright to update the readme to reflect this?